### PR TITLE
smot grep: add ability to do an invert match when patterns are in a file

### DIFF
--- a/smot/main.py
+++ b/smot/main.py
@@ -660,7 +660,10 @@ def grep(
     if file:
         with open(pattern, "r") as f:
             patterns = [p.strip() for p in f.readlines()]
-            matcher = lambda s: any([p in s for p in patterns])
+            if invert_match:
+                matcher = lambda s: not any([p in s for p in patterns])
+            else:
+                matcher = lambda s: any([p in s for p in patterns])
     elif perl:
         regex = re.compile(pattern)
         if invert_match:


### PR DESCRIPTION
Hey Zeb - frequently run into a scenario where I want to drop some tips from a tree with a list in a file (e.g., outliers). So wanted to add the option to do an invert-match on a file, too.